### PR TITLE
Fix/translation default lang

### DIFF
--- a/konfoo/README.md
+++ b/konfoo/README.md
@@ -54,6 +54,7 @@ Changelog
 
 - 1.10.1
     - Fix default_lang when KonfooTranslations initialized with string instead of dict
+    - Make translations object raise ValidationError when data discrepencies
 - 1.10.0
     - Ability to receive `meta` product field values as translation dict
 - 1.9.0

--- a/konfoo/README.md
+++ b/konfoo/README.md
@@ -52,6 +52,8 @@ If you do not need a parameter to be set then the value can be `None` or the key
 Changelog
 ---------
 
+- 1.10.1
+    - Fix default_lang when KonfooTranslations initialized with string instead of dict
 - 1.10.0
     - Ability to receive `meta` product field values as translation dict
 - 1.9.0

--- a/konfoo/__manifest__.py
+++ b/konfoo/__manifest__.py
@@ -1,7 +1,7 @@
 # noinspection PyStatementEffect
 {
     'name': 'Konfoo',
-    'version': '1.10.0',
+    'version': '1.10.1',
     'author': 'Konfoo',
     'website': 'https://konfoo.com',
     'license': 'Other proprietary',

--- a/konfoo/i18n/et_EE.po
+++ b/konfoo/i18n/et_EE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-06 11:49+0000\n"
-"PO-Revision-Date: 2024-11-06 11:49+0000\n"
+"POT-Creation-Date: 2024-11-07 04:58+0000\n"
+"PO-Revision-Date: 2024-11-07 04:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -606,6 +606,20 @@ msgid "Konfoo sync key is not configured"
 msgstr "Konfoo andmesünkroniseeringu võti pole konfigureeritud"
 
 #. module: konfoo
+#. odoo-python
+#: code:addons/konfoo/models/konfoo_api.py:0
+#, python-format
+msgid "Konfoo translations contain inactive lang. codes \"%s\""
+msgstr "Konfoo tõlked sisaldavad mitteaktiivseid keele koode \"%s\""
+
+#. module: konfoo
+#. odoo-python
+#: code:addons/konfoo/models/konfoo_api.py:0
+#, python-format
+msgid "Konfoo translations must contain company lang. code \"%s\""
+msgstr "Konfoo tõlked peavad sisaldama ettevõtte keele koodi \"%s\""
+
+#. module: konfoo
 #: model:ir.model.fields,field_description:konfoo.field_konfoo_allowed_model__write_uid
 #: model:ir.model.fields,field_description:konfoo.field_konfoo_dataset__write_uid
 #: model:ir.model.fields,field_description:konfoo.field_konfoo_dataset_field__write_uid
@@ -813,6 +827,7 @@ msgstr "Konfoo tõlkeobjekti loomine ebaõnnestus"
 
 #. module: konfoo
 #. odoo-python
+#: code:addons/konfoo/models/res_config_settings.py:0
 #: code:addons/konfoo/models/res_config_settings.py:0
 #, python-format
 msgid "Unexpected response from Konfoo: %s"

--- a/konfoo/models/konfoo_api.py
+++ b/konfoo/models/konfoo_api.py
@@ -50,7 +50,8 @@ def safe_eval_objects(eval_str, objects_map, instance_id):
 
 
 class KonfooTranslations(object):
-    default_lang = 'en_US'
+    map_translations = None
+    default_lang = None
     env = None
 
     def _validate_translations_map(self):
@@ -67,13 +68,14 @@ class KonfooTranslations(object):
         if not env and not values:
             raise UserError(_('Unable to create object KonfooTranslations'))
 
+        company_lang = env.user.company_id.partner_id.lang
         if isinstance(values, dict):
             translation_values = values
         else:
-            translation_values = {self.default_lang: values}
+            translation_values = {company_lang: values}
 
-        self.default_lang = env.user.company_id.partner_id.lang
         self.map_translations = translation_values
+        self.default_lang = company_lang
         self.env = env
 
         self._validate_translations_map()
@@ -100,7 +102,7 @@ class KonfooTranslations(object):
             self.map_translations[lang] = value + translation
 
     def __str__(self):
-        return self.map_translations.get(self.default_lang)
+        return self.map_translations[self.default_lang]
 
 
 class KonfooLookupDom(object):

--- a/konfoo/models/konfoo_api.py
+++ b/konfoo/models/konfoo_api.py
@@ -56,13 +56,14 @@ class KonfooTranslations(object):
 
     def _validate_translations_map(self):
         installed_langs = [code for code, _ in self.env['res.lang'].get_installed()]
-        for lang in list(self.map_translations.keys()):
-            if lang not in installed_langs:
-                del self.map_translations[lang]
-                logger.warning('Ignoring "%s" translation - language not installed', lang)
-            elif not isinstance(self.map_translations[lang], str):
-                del self.map_translations[lang]
-                logger.warning('Ignoring "%s" translation - value not string', lang)
+        unavailable_langs = [l for l in self.map_translations.keys() if l not in installed_langs]
+        if len(unavailable_langs) > 0:
+            raise ValidationError(_(
+                'Konfoo translations contain inactive lang. codes "%s"', ', '.join(unavailable_langs)))
+
+        if self.default_lang not in self.map_translations.keys():
+            raise ValidationError(_(
+                'Konfoo translations must contain company lang. code "%s"', self.default_lang))
 
     def __init__(self, env, values):
         if not env and not values:

--- a/konfoo/tests/test_metadata.py
+++ b/konfoo/tests/test_metadata.py
@@ -12,12 +12,12 @@ class TestKonfooMetadata(TransactionCase):
     def setUp(self):
         super().setUp()
 
-        company = self.env.user.company_id
+        self.company = self.env.user.company_id
 
         # NOTE: the values do not matter 'cause we avoid doing any requests
-        company.konfoo_url = company.konfoo_url_staging = 'http://localhost:8000'
-        company.konfoo_client_id_staging = company.konfoo_client_id = 'test'
-        company.konfoo_default_uom_id = self.env.ref('uom.product_uom_unit').id
+        self.company.konfoo_url = self.company.konfoo_url_staging = 'http://localhost:8000'
+        self.company.konfoo_client_id_staging = self.company.konfoo_client_id = 'test'
+        self.company.konfoo_default_uom_id = self.env.ref('uom.product_uom_unit').id
 
         if version_info[:2] < (18, 0):
             self.env['product.product'].create({
@@ -102,30 +102,20 @@ class TestKonfooMetadata(TransactionCase):
         konfoo = self.env['konfoo.api']
         self.assertIsNotNone(konfoo)
 
-        self.env['res.lang']._activate_lang("et_EE")
+        self.env['res.lang']._activate_lang('et_EE')
+        self.company.partner_id.write(dict(lang='et_EE'))
 
         data = json.loads("""
             {
-                "data": [
-                    {
-                        "__id__": "bom_line",
-                        "__instance__": "02YYYYYYYYYYYYYYYYYYYYYYYY",
-                        "model": "mrp.bom.line",
-                        "product_id := product.product.default_code": "MOCK-PRODUCT",
-                        "product_qty": 2,
-                        "product_uom_id := uom.uom.name": "Units"
-                    }
-                ],
+                "data": [],
                 "meta": {
                     "name": {
-                        "et_EE": "Test Konfigureeritud Toode",
-                        "en_US": "Mock Configured Product",
-                        "et_US": "Invalid LANG Option"
+                        "et_EE": "Mock Configured Product EE",
+                        "en_US": "Mock Configured Product US"
                     },
                     "description": {
-                        "et_EE": "<b>Toote Kirjeldus</b>",
-                        "en_US": "<b>Product Description</b>",
-                        "et_US": "<b>Invalid LANG Option</b>"
+                        "et_EE": "<b>Product Description EE</b>",
+                        "en_US": "<b>Product Description US</b>"
                     },
                     "template_product": "MOCK-KONFOO-TEMPLATE",
                     "product_name_delimiter": "-",
@@ -150,9 +140,6 @@ class TestKonfooMetadata(TransactionCase):
         konfoo.process_konfoo_session(ctx, '02XXXXXXXXXXXXXXXXXXXXXXXX', dict(), data, order, 'sale.order.line')
         self.assertEqual(order.origin, 'Made by Konfoo')
         self.assertEqual(len(order.order_line), 1)
-        if version_info[:2] < (16, 0):
-            self.assertEqual(order.order_line.name, f'{order.name}-Mock Configured Product')
-        else:
-            self.assertEqual(order.order_line.name, f'{order.name}-Test Konfigureeritud Toode')
-        self.assertEqual(order.order_line.product_id.description, '<b>Product Description</b>')
-        self.assertEqual(order.order_line.product_id.name, f'{order.name}-Mock Configured Product')
+        self.assertEqual(order.order_line.name, f'{order.name}-Mock Configured Product EE')
+        self.assertEqual(order.order_line.product_id.description, '<b>Product Description US</b>')
+        self.assertEqual(order.order_line.product_id.name, f'{order.name}-Mock Configured Product US')


### PR DESCRIPTION

Üks kriitiline viga mida testid ei tabanud

- KonfooTranslations objekti loomel sai default_lang väärtustatud company keelega liiga hilja. Sellest tulenevalt eesti keelega ettevõtete puhul tekib key error. Kuna välja väärtus sattus vaikimis hoopis en_US key alla.

- Lisaks muutsin valideerimisel vigade logimise ValidationError peale
